### PR TITLE
Interpolator retrieving crash fix

### DIFF
--- a/sample/src/main/kotlin/app/futured/donutsample/ui/playground/PlaygroundActivity.kt
+++ b/sample/src/main/kotlin/app/futured/donutsample/ui/playground/PlaygroundActivity.kt
@@ -229,8 +229,13 @@ class PlaygroundActivity : AppCompatActivity() {
             AnimationUtils.loadInterpolator(this, android.R.interpolator.bounce)
         )
 
-        interpolator_radio_group.setOnCheckedChangeListener { _, checkedId ->
-            donut_view.animationInterpolator = interpolators[checkedId - 1]
+        interpolator_radio_group.setOnCheckedChangeListener { radioGroup, checkedId ->
+            for (i in 0 until radioGroup.childCount) {
+                if (radioGroup.getChildAt(i).id == checkedId) {
+                    donut_view.animationInterpolator = interpolators[i]
+                    break
+                }
+            }
         }
 
         // endregion


### PR DESCRIPTION
Fixes crash when id of selected interpolator from RadioGroup was out of range of interpolators list.